### PR TITLE
Fix calculation of time value

### DIFF
--- a/src/hxlive/DateCompare.hx
+++ b/src/hxlive/DateCompare.hx
@@ -31,8 +31,8 @@ class DateCompare
 
 	public static function compare(d1:Date, d2:Date)
 	{
-		var d1Result = d1.getSeconds() * d1.getMinutes() * d1.getHours();
-		var d2Result = d2.getSeconds() * d2.getMinutes() * d2.getHours();
+		var d1Result = d1.getSeconds() + d1.getMinutes() * 60 + d1.getHours() * 3600;
+		var d2Result = d2.getSeconds() + d2.getMinutes() * 60 + d2.getHours() * 3600;
 		
 		if (d1Result > d2Result)
 			return 1;


### PR DESCRIPTION
Now DateCompare calculate the number of seconds in both date for comparison,

before you could have "00:10:00" before "01:00:00'.
